### PR TITLE
Refactor controller to move header parsing to action.

### DIFF
--- a/app/controllers/MessageController.scala
+++ b/app/controllers/MessageController.scala
@@ -16,35 +16,26 @@
 
 package controllers
 
-import config.AppConfig
 import connectors.DestinationConnector
+import controllers.actions.MessageRecipientIdentifierActionProvider
 import javax.inject.Inject
-import play.api.Logger
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.xml.NodeSeq
 
 class MessageController @Inject()(
-  appConfig: AppConfig,
+  messageRecipientIdentifier: MessageRecipientIdentifierActionProvider,
   cc: ControllerComponents,
   connector: DestinationConnector
 )(implicit val ec: ExecutionContext)
     extends BackendController(cc) {
 
-  private lazy val logger = Logger(getClass)
-
-  def handleMessage(): Action[NodeSeq] = Action.async(parse.xml) {
-    implicit request =>
-      request.headers.get("X-Message-Recipient") match {
-        case Some(xMessageSender) =>
-          connector
-            .sendMessage(xMessageSender, request.body, request.headers)
-            .map(response => Status(response.status))
-        case None =>
-          logger.error("BadRequest: missing header key X-Message-Recipient")
-          Future.successful(BadRequest)
-      }
-  }
+  def handleMessage(): Action[NodeSeq] =
+    messageRecipientIdentifier().async(parse.xml) { implicit request =>
+      connector
+        .sendMessage(request.messageRecipient, request.body, request.headers)
+        .map(response => Status(response.status))
+    }
 }

--- a/app/controllers/actions/MessageRecipientIdentifierAction.scala
+++ b/app/controllers/actions/MessageRecipientIdentifierAction.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import com.google.inject.Inject
+import models.requests
+import models.requests.MessageRecipientRequest
+import play.api.{Logger, mvc}
+import play.api.mvc._
+import play.api.mvc.Results.BadRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MessageRecipientIdentifierActionProvider @Inject()(
+  buildDefault: DefaultActionBuilder
+)(implicit val executionContext: ExecutionContext) {
+  def apply(): ActionBuilder[MessageRecipientRequest, AnyContent] =
+    buildDefault andThen (new MessageRecipientIdentifierAction(
+      executionContext
+    ))
+}
+
+class MessageRecipientIdentifierAction(val executionContext: ExecutionContext)
+    extends ActionRefiner[Request, MessageRecipientRequest] {
+
+  private lazy val logger = Logger(getClass)
+
+  override protected def refine[A](
+    request: Request[A]
+  ): Future[Either[Result, MessageRecipientRequest[A]]] =
+    Future.successful {
+      request.headers
+        .get("X-Message-Recipient")
+        .toRight {
+          logger.error("BadRequest: missing header key X-Message-Recipient")
+          BadRequest
+        }
+        .right
+        .map(requests.MessageRecipientRequest(request, _))
+    }
+}

--- a/app/models/requests/MessageRecipientRequest.scala
+++ b/app/models/requests/MessageRecipientRequest.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+import play.api.mvc.{Request, WrappedRequest}
+
+case class MessageRecipientRequest[A](request: Request[A],
+                                      messageRecipient: String)
+    extends WrappedRequest[A](request)

--- a/test/controllers/actions/MessageRecipientIdentifierActionSpec.scala
+++ b/test/controllers/actions/MessageRecipientIdentifierActionSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import play.api.mvc._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+import scala.concurrent.Future
+
+class MessageRecipientIdentifierActionSpec extends SpecBase {
+
+  class Harness(action: MessageRecipientIdentifierActionProvider) {
+
+    def run(): Action[AnyContent] = action() { result =>
+      Results.Ok("")
+    }
+  }
+
+  private def actionProvider =
+    applicationBuilder
+      .build()
+      .injector
+      .instanceOf[MessageRecipientIdentifierActionProvider]
+
+  private val xMessageRecipient = "MDTP-1-1"
+
+  "MessageSenderIdentifierAction" - {
+    "must return an BadRequest when the X-Message-Recipient is missing" in {
+      def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
+
+      val controller: Harness = new Harness(actionProvider)
+
+      val result: Future[Result] = controller.run()(fakeRequest)
+
+      status(result) mustEqual BAD_REQUEST
+    }
+
+    "will process the action when the X-Message-Recipient is present" in {
+      def fakeRequest: FakeRequest[AnyContentAsEmpty.type] =
+        FakeRequest("", "").withHeaders(
+          "X-Message-Recipient" -> xMessageRecipient
+        )
+
+      val controller: Harness = new Harness(actionProvider)
+
+      val result: Future[Result] = controller.run()(fakeRequest)
+
+      status(result) mustEqual OK
+    }
+
+  }
+}


### PR DESCRIPTION
Create action to get the X-Message-Recipient from header
If the header is absent a Bad Request is returned.